### PR TITLE
Custom buffer local string inflection function

### DIFF
--- a/evil-string-inflection.el
+++ b/evil-string-inflection.el
@@ -31,6 +31,11 @@
 (require 'evil)
 (require 'string-inflection)
 
+(defvar evil-string-inflection-func 'string-inflection-all-cycle-function
+  "The function to use when calling the operator.")
+
+(make-local-variable 'evil-string-inflection-func)
+
 ;;;###autoload
 (autoload 'evil-string-inflection "evil-string-inflection.el"
   "Define a new evil operator that cicles underscore -> UPCASE -> CamelCase." t)
@@ -42,7 +47,7 @@
   (let ((str (buffer-substring-no-properties beg end)))
     (save-excursion
       (delete-region beg end)
-      (insert (string-inflection-all-cycle-function str)))))
+      (insert (funcall evil-string-inflection-func str)))))
 
 (define-key evil-normal-state-map (kbd "g~") 'evil-operator-string-inflection)
 

--- a/readme.org
+++ b/readme.org
@@ -52,6 +52,15 @@ CamelCaseWord
   (define-key evil-normal-state-map "gR" 'evil-operator-string-inflection)
 #+END_SRC
 
+- you can change the cycle function per buffer type, for example:
+
+#+BEGIN_SRC emacs-lisp
+
+(add-hook 'typescript-mode-hook (lambda ()
+                                  (setq evil-string-inflection-func 'string-inflection-java-style-cycle-function)))
+
+#+END_SRC
+
 * LICENSE
 
 - [[https://www.gnu.org/licenses/gpl-3.0.en.html][GNU General Public License v3]]


### PR DESCRIPTION
With this PR we can specify an specific function to rotate the text if needed, for example:

```elisp
(add-hook 'typescript-mode-hook (lambda ()
                                   (setq evil-string-inflection-func 'string-inflection-java-style-cycle-function)))
```

would use the `string-inflection-java-style-cycle-function` function for any typescript buffer.

thank you very much for the feedback!